### PR TITLE
feat: add profile service skeleton

### DIFF
--- a/configuration.yml
+++ b/configuration.yml
@@ -15,3 +15,15 @@ nats:
   NATS_AUTH_NKEY_SEED: SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 keycloak:
   jwksUri: http://localhost:8080/.well-known/jwks.json
+alternator:
+  endpoint: http://scylla-node:8000
+  region: eu-west-1
+tables:
+  events: profiles_events
+  snapshots: profiles_snapshots
+  idem: profiles_idem
+  locks: profiles_username_locks
+snapshots:
+  every: 100
+idempotency:
+  ttlSec: 86400

--- a/src/application/controllers/health.controller.ts
+++ b/src/application/controllers/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@midwayjs/decorator';
+
+@Controller('/api/v1')
+export class HealthController {
+  @Get('/health')
+  async health() {
+    return { status: 'ok' };
+    }
+}

--- a/src/application/controllers/profile.controller.ts
+++ b/src/application/controllers/profile.controller.ts
@@ -1,0 +1,67 @@
+import { Controller, Get, Param, Query, Put, Patch, Body, Headers } from '@midwayjs/decorator';
+import { Inject } from '@midwayjs/core';
+import { ProfileService } from '../../domain/services/profile.service';
+import { ProfileCreateInput, ProfilePatchInput } from '../dtos/profile.dto';
+
+@Controller('/api/v1')
+export class ProfileController {
+  @Inject()
+  profileService: ProfileService;
+
+  @Get('/profiles/:userId')
+  async getById(@Param('userId') userId: string, @Query('version') version?: number) {
+    const v = typeof version === 'string' ? parseInt(version) : undefined;
+    try {
+      return await this.profileService.getByUserId(userId, v);
+    } catch (e) {
+      return { error: 'NOT_FOUND' };
+    }
+  }
+
+  @Get('/profiles/by-username/:username')
+  async getByUsername(@Param('username') username: string) {
+    try {
+      return await this.profileService.getByUsername(username);
+    } catch (e) {
+      return { error: 'NOT_FOUND' };
+    }
+  }
+
+  @Put('/profiles/:userId')
+  async create(
+    @Param('userId') userId: string,
+    @Body() body: ProfileCreateInput,
+    @Headers('x-idempotency-key') idem?: string
+  ) {
+    try {
+      const profile = await this.profileService.create(userId, body, idem);
+      return profile;
+    } catch (e) {
+      if ((e as Error).message === 'username taken') {
+        return { error: 'CONFLICT' };
+      }
+      return { error: 'VALIDATION_ERROR' };
+    }
+  }
+
+  @Patch('/profiles/:userId')
+  async patch(
+    @Param('userId') userId: string,
+    @Body() body: ProfilePatchInput,
+    @Headers('if-match') ifMatch: string
+  ) {
+    const match = /\d+/.exec(ifMatch || '');
+    const expected = match ? parseInt(match[0]) : NaN;
+    try {
+      return await this.profileService.patch(userId, body, expected);
+    } catch (e) {
+      if ((e as Error).message === 'version mismatch') {
+        return { error: 'PRECONDITION_FAILED' };
+      }
+      if ((e as Error).message === 'username taken') {
+        return { error: 'CONFLICT' };
+      }
+      return { error: 'NOT_FOUND' };
+    }
+  }
+}

--- a/src/application/dtos/profile.dto.ts
+++ b/src/application/dtos/profile.dto.ts
@@ -1,0 +1,29 @@
+export interface ProfileDTO {
+  user_id: string;
+  username: string;
+  display_name: string;
+  bio?: string;
+  locale?: string;
+  avatar_url?: string;
+  version: number;
+  created_at: string;
+  updated_at: string;
+  phone_e164?: string | null;
+  birth_date?: string | null;
+}
+
+export interface ProfileCreateInput {
+  username: string;
+  display_name: string;
+  bio?: string;
+  locale?: string;
+  avatar_url?: string;
+}
+
+export interface ProfilePatchInput {
+  username?: string;
+  display_name?: string;
+  bio?: string;
+  locale?: string;
+  avatar_url?: string;
+}

--- a/src/application/dtos/validators.ts
+++ b/src/application/dtos/validators.ts
@@ -1,0 +1,41 @@
+import { ProfileCreateInput, ProfilePatchInput } from './profile.dto';
+
+const USERNAME_REGEX = /^[a-z0-9._-]{3,32}$/;
+
+export function validateCreateInput(input: ProfileCreateInput): string | null {
+  if (!USERNAME_REGEX.test(input.username)) {
+    return 'invalid username';
+  }
+  if (!input.display_name || input.display_name.length < 1 || input.display_name.length > 64) {
+    return 'invalid display_name';
+  }
+  if (input.bio && input.bio.length > 2048) {
+    return 'invalid bio';
+  }
+  if (input.locale && input.locale.length > 16) {
+    return 'invalid locale';
+  }
+  if (input.avatar_url && !/^https?:\/\//.test(input.avatar_url)) {
+    return 'invalid avatar_url';
+  }
+  return null;
+}
+
+export function validatePatchInput(input: ProfilePatchInput): string | null {
+  if (input.username && !USERNAME_REGEX.test(input.username)) {
+    return 'invalid username';
+  }
+  if (input.display_name && (input.display_name.length < 1 || input.display_name.length > 64)) {
+    return 'invalid display_name';
+  }
+  if (input.bio && input.bio.length > 2048) {
+    return 'invalid bio';
+  }
+  if (input.locale && input.locale.length > 16) {
+    return 'invalid locale';
+  }
+  if (input.avatar_url && !/^https?:\/\//.test(input.avatar_url)) {
+    return 'invalid avatar_url';
+  }
+  return null;
+}

--- a/src/domain/aggregate/profile.aggregate.ts
+++ b/src/domain/aggregate/profile.aggregate.ts
@@ -1,0 +1,73 @@
+export type ProfileEventType = 'ProfileCreated' | 'ProfilePatched';
+
+export interface ProfileCreated {
+  type: 'ProfileCreated';
+  payload: {
+    username: string;
+    display_name: string;
+    bio?: string;
+    locale?: string;
+    avatar_url?: string;
+    created_at: string;
+  };
+}
+
+export interface ProfilePatched {
+  type: 'ProfilePatched';
+  payload: {
+    username?: string;
+    display_name?: string;
+    bio?: string;
+    locale?: string;
+    avatar_url?: string;
+    updated_at: string;
+  };
+}
+
+export type ProfileEvent = ProfileCreated | ProfilePatched;
+
+export interface ProfileState {
+  user_id: string;
+  username: string;
+  display_name: string;
+  bio?: string;
+  locale?: string;
+  avatar_url?: string;
+  created_at: string;
+  updated_at: string;
+  phone_e164?: string | null;
+  birth_date?: string | null;
+  version: number;
+}
+
+export function reduce(state: ProfileState | null, event: ProfileEvent, userId: string, seq: number): ProfileState {
+  if (event.type === 'ProfileCreated') {
+    return {
+      user_id: userId,
+      username: event.payload.username,
+      display_name: event.payload.display_name,
+      bio: event.payload.bio,
+      locale: event.payload.locale,
+      avatar_url: event.payload.avatar_url,
+      created_at: event.payload.created_at,
+      updated_at: event.payload.created_at,
+      phone_e164: null,
+      birth_date: null,
+      version: seq,
+    };
+  }
+  if (!state) throw new Error('state not initialized');
+  if (event.type === 'ProfilePatched') {
+    return {
+      ...state,
+      username: event.payload.username ?? state.username,
+      display_name: event.payload.display_name ?? state.display_name,
+      bio: event.payload.bio ?? state.bio,
+      locale: event.payload.locale ?? state.locale,
+      avatar_url: event.payload.avatar_url ?? state.avatar_url,
+      updated_at: event.payload.updated_at,
+      version: seq,
+    };
+  }
+  return state;
+}

--- a/src/domain/ports/in/profile.service.interface.ts
+++ b/src/domain/ports/in/profile.service.interface.ts
@@ -1,0 +1,8 @@
+import { ProfileDTO, ProfileCreateInput, ProfilePatchInput } from '../../../application/dtos/profile.dto';
+
+export interface ProfileServiceInterface {
+  getByUserId(userId: string, version?: number): Promise<ProfileDTO>;
+  getByUsername(username: string): Promise<ProfileDTO>;
+  create(userId: string, input: ProfileCreateInput, idempotencyKey?: string): Promise<ProfileDTO>;
+  patch(userId: string, input: ProfilePatchInput, expectedVersion: number): Promise<ProfileDTO>;
+}

--- a/src/domain/ports/out/idempotency.repository.interface.ts
+++ b/src/domain/ports/out/idempotency.repository.interface.ts
@@ -1,0 +1,3 @@
+export interface IdempotencyRepository {
+  checkAndPut(scope: string, key: string, ttlSec: number): Promise<boolean>;
+}

--- a/src/domain/ports/out/profile.eventstore.interface.ts
+++ b/src/domain/ports/out/profile.eventstore.interface.ts
@@ -1,0 +1,7 @@
+import { ProfileEvent } from '../../aggregate/profile.aggregate';
+
+export interface ProfileEventStore {
+  append(userId: string, event: ProfileEvent, expectedSeq?: number): Promise<{ seq: number }>;
+  loadAfter(userId: string, lastSeq: number, limit?: number): Promise<{ seq: number; event: ProfileEvent }[]>;
+  loadLast(userId: string): Promise<{ seq: number; event?: ProfileEvent } | null>;
+}

--- a/src/domain/ports/out/profile.snapshotstore.interface.ts
+++ b/src/domain/ports/out/profile.snapshotstore.interface.ts
@@ -1,0 +1,6 @@
+import { ProfileState } from '../../aggregate/profile.aggregate';
+
+export interface ProfileSnapshotStore {
+  getLatest(userId: string): Promise<{ state: ProfileState; last_seq: number; version: number } | null>;
+  put(userId: string, state: ProfileState, version: number, last_seq: number): Promise<void>;
+}

--- a/src/domain/ports/out/usernamelock.repository.interface.ts
+++ b/src/domain/ports/out/usernamelock.repository.interface.ts
@@ -1,0 +1,6 @@
+export interface UsernameLockRepository {
+  acquire(username: string, ownerUserId: string): Promise<void>;
+  switch(oldUsername: string, newUsername: string, ownerUserId: string): Promise<void>;
+  getOwner(username: string): Promise<string | null>;
+  release(username: string): Promise<void>;
+}

--- a/src/domain/services/profile.service.ts
+++ b/src/domain/services/profile.service.ts
@@ -1,0 +1,101 @@
+import { Provide, Inject } from '@midwayjs/decorator';
+import { ProfileServiceInterface } from '../ports/in/profile.service.interface';
+import { ProfileEventStore } from '../ports/out/profile.eventstore.interface';
+import { ProfileSnapshotStore } from '../ports/out/profile.snapshotstore.interface';
+import { IdempotencyRepository } from '../ports/out/idempotency.repository.interface';
+import { UsernameLockRepository } from '../ports/out/usernamelock.repository.interface';
+import { ProfileDTO, ProfileCreateInput, ProfilePatchInput } from '../../application/dtos/profile.dto';
+import { ProfileState, reduce, ProfileEvent } from '../aggregate/profile.aggregate';
+import { validateCreateInput, validatePatchInput } from '../../application/dtos/validators';
+
+const SNAPSHOT_EVERY = 100;
+const IDEMP_TTL = 86400;
+
+@Provide('ProfileService')
+export class ProfileService implements ProfileServiceInterface {
+  @Inject('EventStore')
+  private eventStore: ProfileEventStore;
+
+  @Inject('SnapshotStore')
+  private snapshotStore: ProfileSnapshotStore;
+
+  @Inject('IdempotencyRepo')
+  private idempotencyRepo: IdempotencyRepository;
+
+  @Inject('UsernameLockRepo')
+  private usernameLockRepo: UsernameLockRepository;
+
+  private async loadState(userId: string, version?: number): Promise<{ state: ProfileState | null; seq: number }> {
+    const snapshot = await this.snapshotStore.getLatest(userId);
+    let state: ProfileState | null = snapshot ? snapshot.state : null;
+    let seq = snapshot ? snapshot.last_seq : 0;
+    const events = await this.eventStore.loadAfter(userId, seq);
+    for (const { seq: s, event } of events) {
+      if (version && s > version) break;
+      state = reduce(state, event, userId, s);
+      seq = s;
+    }
+    return { state, seq };
+  }
+
+  async getByUserId(userId: string, version?: number): Promise<ProfileDTO> {
+    const { state } = await this.loadState(userId, version);
+    if (!state) throw new Error('not found');
+    return state;
+  }
+
+  async getByUsername(username: string): Promise<ProfileDTO> {
+    // naive search through snapshots
+    const allUserIds = await this.usernameLockRepo.getOwner(username);
+    if (!allUserIds) throw new Error('not found');
+    return this.getByUserId(allUserIds);
+  }
+
+  async create(userId: string, input: ProfileCreateInput, idempotencyKey?: string): Promise<ProfileDTO> {
+    const validation = validateCreateInput(input);
+    if (validation) throw new Error(validation);
+    if (idempotencyKey) {
+      const existed = await this.idempotencyRepo.checkAndPut('profile:create', idempotencyKey, IDEMP_TTL);
+      if (existed) {
+        const { state } = await this.loadState(userId);
+        if (state) return state;
+      }
+    }
+    await this.usernameLockRepo.acquire(input.username, userId);
+    const now = new Date().toISOString();
+    const event: ProfileEvent = {
+      type: 'ProfileCreated',
+      payload: { ...input, created_at: now }
+    };
+    const last = await this.eventStore.loadLast(userId);
+    const seq = (last?.seq ?? 0) + 1;
+    await this.eventStore.append(userId, event, last?.seq);
+    let state = reduce(null, event, userId, seq);
+    if (seq % SNAPSHOT_EVERY === 0) {
+      await this.snapshotStore.put(userId, state, seq, seq);
+    }
+    return state;
+  }
+
+  async patch(userId: string, input: ProfilePatchInput, expectedVersion: number): Promise<ProfileDTO> {
+    const validation = validatePatchInput(input);
+    if (validation) throw new Error(validation);
+    const { state: current, seq } = await this.loadState(userId);
+    if (!current) throw new Error('not found');
+    if (current.version !== expectedVersion) {
+      throw new Error('version mismatch');
+    }
+    if (input.username && input.username !== current.username) {
+      await this.usernameLockRepo.switch(current.username, input.username, userId);
+    }
+    const now = new Date().toISOString();
+    const event: ProfileEvent = { type: 'ProfilePatched', payload: { ...input, updated_at: now } };
+    const nextSeq = seq + 1;
+    await this.eventStore.append(userId, event, seq);
+    const newState = reduce(current, event, userId, nextSeq);
+    if (nextSeq % SNAPSHOT_EVERY === 0) {
+      await this.snapshotStore.put(userId, newState, nextSeq, nextSeq);
+    }
+    return newState;
+  }
+}

--- a/src/infrastructure/adapters/database/alternator/alternator.client.ts
+++ b/src/infrastructure/adapters/database/alternator/alternator.client.ts
@@ -1,0 +1,6 @@
+import { Provide } from '@midwayjs/decorator';
+
+@Provide()
+export class AlternatorClient {
+  // placeholder for AWS SDK client
+}

--- a/src/infrastructure/adapters/database/alternator/eventstore.repository.ts
+++ b/src/infrastructure/adapters/database/alternator/eventstore.repository.ts
@@ -1,0 +1,32 @@
+import { Provide, Scope, ScopeEnum } from '@midwayjs/decorator';
+import { ProfileEventStore } from '../../../../domain/ports/out/profile.eventstore.interface';
+import { ProfileEvent } from '../../../../domain/aggregate/profile.aggregate';
+
+@Provide('EventStore')
+@Scope(ScopeEnum.Singleton)
+export class InMemoryEventStore implements ProfileEventStore {
+  private events: Map<string, { seq: number; event: ProfileEvent }[]> = new Map();
+
+  async append(userId: string, event: ProfileEvent, expectedSeq?: number): Promise<{ seq: number }> {
+    const list = this.events.get(userId) || [];
+    const lastSeq = list.length > 0 ? list[list.length - 1].seq : 0;
+    if (expectedSeq !== undefined && expectedSeq !== lastSeq) {
+      throw new Error('wrong seq');
+    }
+    const nextSeq = lastSeq + 1;
+    list.push({ seq: nextSeq, event });
+    this.events.set(userId, list);
+    return { seq: nextSeq };
+  }
+
+  async loadAfter(userId: string, lastSeq: number, limit = 100): Promise<{ seq: number; event: ProfileEvent }[]> {
+    const list = this.events.get(userId) || [];
+    return list.filter(e => e.seq > lastSeq).slice(0, limit);
+  }
+
+  async loadLast(userId: string): Promise<{ seq: number; event?: ProfileEvent } | null> {
+    const list = this.events.get(userId) || [];
+    if (list.length === 0) return null;
+    return list[list.length - 1];
+  }
+}

--- a/src/infrastructure/adapters/database/alternator/idempotency.repository.ts
+++ b/src/infrastructure/adapters/database/alternator/idempotency.repository.ts
@@ -1,0 +1,19 @@
+import { Provide, Scope, ScopeEnum } from '@midwayjs/decorator';
+import { IdempotencyRepository } from '../../../../domain/ports/out/idempotency.repository.interface';
+
+@Provide('IdempotencyRepo')
+@Scope(ScopeEnum.Singleton)
+export class InMemoryIdempotencyRepository implements IdempotencyRepository {
+  private store: Map<string, number> = new Map();
+
+  async checkAndPut(scope: string, key: string, ttlSec: number): Promise<boolean> {
+    const composite = `${scope}:${key}`;
+    const now = Date.now();
+    const exists = this.store.get(composite);
+    if (exists && exists > now) {
+      return true;
+    }
+    this.store.set(composite, now + ttlSec * 1000);
+    return false;
+  }
+}

--- a/src/infrastructure/adapters/database/alternator/snapshot.repository.ts
+++ b/src/infrastructure/adapters/database/alternator/snapshot.repository.ts
@@ -1,0 +1,17 @@
+import { Provide, Scope, ScopeEnum } from '@midwayjs/decorator';
+import { ProfileSnapshotStore } from '../../../../domain/ports/out/profile.snapshotstore.interface';
+import { ProfileState } from '../../../../domain/aggregate/profile.aggregate';
+
+@Provide('SnapshotStore')
+@Scope(ScopeEnum.Singleton)
+export class InMemorySnapshotStore implements ProfileSnapshotStore {
+  private snapshots: Map<string, { state: ProfileState; last_seq: number; version: number }> = new Map();
+
+  async getLatest(userId: string): Promise<{ state: ProfileState; last_seq: number; version: number } | null> {
+    return this.snapshots.get(userId) || null;
+  }
+
+  async put(userId: string, state: ProfileState, version: number, last_seq: number): Promise<void> {
+    this.snapshots.set(userId, { state, version, last_seq });
+  }
+}

--- a/src/infrastructure/adapters/database/alternator/usernamelock.repository.ts
+++ b/src/infrastructure/adapters/database/alternator/usernamelock.repository.ts
@@ -1,0 +1,37 @@
+import { Provide, Scope, ScopeEnum } from '@midwayjs/decorator';
+import { UsernameLockRepository } from '../../../../domain/ports/out/usernamelock.repository.interface';
+
+@Provide('UsernameLockRepo')
+@Scope(ScopeEnum.Singleton)
+export class InMemoryUsernameLockRepository implements UsernameLockRepository {
+  private locks: Map<string, string> = new Map();
+
+  async acquire(username: string, ownerUserId: string): Promise<void> {
+    const existing = this.locks.get(username);
+    if (existing && existing !== ownerUserId) {
+      throw new Error('username taken');
+    }
+    this.locks.set(username, ownerUserId);
+  }
+
+  async switch(oldUsername: string, newUsername: string, ownerUserId: string): Promise<void> {
+    const owner = this.locks.get(oldUsername);
+    if (owner !== ownerUserId) {
+      throw new Error('lock mismatch');
+    }
+    const existing = this.locks.get(newUsername);
+    if (existing && existing !== ownerUserId) {
+      throw new Error('username taken');
+    }
+    this.locks.delete(oldUsername);
+    this.locks.set(newUsername, ownerUserId);
+  }
+
+  async getOwner(username: string): Promise<string | null> {
+    return this.locks.get(username) || null;
+  }
+
+  async release(username: string): Promise<void> {
+    this.locks.delete(username);
+  }
+}


### PR DESCRIPTION
## Summary
- implement profile aggregate, service, and REST controllers
- add in-memory repositories and configuration entries
- expose health endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6899443b3eec83229d376aff285f2c31