### PR TITLE
feat: snapshot profile after creation and every ten events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,74 @@
-# my_midway_project
+# Profile Service
 
-## QuickStart
+A Midway-based service that manages user profiles using event sourcing with snapshots.
 
-<!-- add docs here for user -->
+## English
 
-see [midway docs][midway] for more detail.
-
-### Development
+### Running
 
 ```bash
-$ npm i
-$ npm run dev
-$ open http://localhost:7001/
+npm install
+npm run dev
 ```
 
-### Deploy
+### API
+
+| Method | Path                                  | Description                  |
+| ------ | ------------------------------------- | ---------------------------- |
+| GET    | `/api/v1/health`                      | health check                 |
+| GET    | `/profiles/:userId`                   | get profile by user id       |
+| GET    | `/profiles/by-username/:username`     | get profile by username      |
+| PUT    | `/profiles/:userId`                   | create profile               |
+| PATCH  | `/profiles/:userId`                   | update profile               |
+
+### Creating a profile
+
+```http
+PUT /profiles/<userId>
+Content-Type: application/json
+
+{
+  "username": "john",
+  "display_name": "John",
+  "bio": "about me"
+}
+```
+
+## Русский
+
+### Запуск
 
 ```bash
-$ npm start
+npm install
+npm run dev
 ```
 
-### npm scripts
+### API
 
-- Use `npm run lint` to check code style.
-- Use `npm test` to run unit test.
+| Метод | Путь                                   | Описание                     |
+| ----- | -------------------------------------- | ---------------------------- |
+| GET   | `/api/v1/health`                       | проверка состояния           |
+| GET   | `/profiles/:userId`                    | получить профиль по userId   |
+| GET   | `/profiles/by-username/:username`      | получить профиль по имени    |
+| PUT   | `/profiles/:userId`                    | создать профиль              |
+| PATCH | `/profiles/:userId`                    | изменить профиль             |
 
+### Создание профиля
 
-[midway]: https://midwayjs.org
+```http
+PUT /profiles/<userId>
+Content-Type: application/json
+
+{
+  "username": "john",
+  "display_name": "John",
+  "bio": "about me"
+}
+```
+
+### Tests
+
+```bash
+npm test
+```
+

--- a/test/profile.service.test.ts
+++ b/test/profile.service.test.ts
@@ -1,0 +1,116 @@
+import { ProfileService } from '../src/domain/services/profile.service';
+import { ProfileCreateInput } from '../src/application/dtos/profile.dto';
+import { ProfileEvent } from '../src/domain/aggregate/profile.aggregate';
+import { ProfileEventStore } from '../src/domain/ports/out/profile.eventstore.interface';
+import { ProfileSnapshotStore } from '../src/domain/ports/out/profile.snapshotstore.interface';
+import { IdempotencyRepository } from '../src/domain/ports/out/idempotency.repository.interface';
+import { UsernameLockRepository } from '../src/domain/ports/out/usernamelock.repository.interface';
+
+class MemoryEventStore implements ProfileEventStore {
+  private data = new Map<string, { seq: number; event: ProfileEvent }[]>();
+  async append(userId: string, event: ProfileEvent, expectedSeq?: number) {
+    const list = this.data.get(userId) ?? [];
+    const lastSeq = list.length ? list[list.length - 1].seq : 0;
+    if (expectedSeq !== undefined && expectedSeq !== lastSeq) {
+      throw new Error('seq mismatch');
+    }
+    const seq = lastSeq + 1;
+    list.push({ seq, event });
+    this.data.set(userId, list);
+    return { seq };
+  }
+  async loadAfter(userId: string, lastSeq: number) {
+    const list = this.data.get(userId) ?? [];
+    return list.filter(r => r.seq > lastSeq);
+  }
+  async loadLast(userId: string) {
+    const list = this.data.get(userId) ?? [];
+    if (list.length === 0) return null;
+    return list[list.length - 1];
+  }
+}
+
+class MemorySnapshotStore implements ProfileSnapshotStore {
+  private data = new Map<string, { state: any; last_seq: number; version: number }>();
+  async getLatest(userId: string) {
+    return this.data.get(userId) ?? null;
+  }
+  async put(userId: string, state: any, version: number, last_seq: number) {
+    this.data.set(userId, { state, version, last_seq });
+  }
+}
+
+class MemoryIdempotencyRepo implements IdempotencyRepository {
+  private keys = new Set<string>();
+  async checkAndPut(scope: string, key: string, ttlSec: number) {
+    const composite = scope + ':' + key;
+    if (this.keys.has(composite)) return true;
+    this.keys.add(composite);
+    return false;
+  }
+}
+
+class MemoryUsernameLockRepo implements UsernameLockRepository {
+  private locks = new Map<string, string>();
+  async acquire(username: string, ownerUserId: string) {
+    const owner = this.locks.get(username);
+    if (owner && owner !== ownerUserId) throw new Error('locked');
+    this.locks.set(username, ownerUserId);
+  }
+  async switch(oldUsername: string, newUsername: string, ownerUserId: string) {
+    await this.acquire(newUsername, ownerUserId);
+    this.locks.delete(oldUsername);
+  }
+  async getOwner(username: string) {
+    return this.locks.get(username) ?? null;
+  }
+  async release(username: string) {
+    this.locks.delete(username);
+  }
+}
+
+function createService() {
+  const svc = new ProfileService();
+  (svc as any).eventStore = new MemoryEventStore();
+  (svc as any).snapshotStore = new MemorySnapshotStore();
+  (svc as any).idempotencyRepo = new MemoryIdempotencyRepo();
+  (svc as any).usernameLockRepo = new MemoryUsernameLockRepo();
+  return svc;
+}
+
+describe('ProfileService snapshot logic', () => {
+  it('creates snapshot on first event', async () => {
+    const svc = createService();
+    const input: ProfileCreateInput = { username: 'john', display_name: 'John' };
+    const state = await svc.create('u1', input);
+    expect(state.version).toBe(1);
+    const snap = await (svc as any).snapshotStore.getLatest('u1');
+    expect(snap).not.toBeNull();
+    expect(snap.version).toBe(1);
+  });
+
+  it('creates snapshot every 10 events', async () => {
+    const svc = createService();
+    const input: ProfileCreateInput = { username: 'john', display_name: 'John' };
+    await svc.create('u1', input);
+    let version = 1;
+    for (let i = 0; i < 9; i++) {
+      version++;
+      await svc.patch('u1', { display_name: 'John' + i }, version - 1);
+    }
+    const snap = await (svc as any).snapshotStore.getLatest('u1');
+    expect(snap.version).toBe(10);
+    expect(snap.last_seq).toBe(10);
+  });
+
+  it('returns snapshot state when no events after snapshot', async () => {
+    const svc = createService();
+    const input: ProfileCreateInput = { username: 'jack', display_name: 'Jack' };
+    await svc.create('u2', input);
+    const state = await svc.getByUserId('u2');
+    expect(state.username).toBe('jack');
+    const snap = await (svc as any).snapshotStore.getLatest('u2');
+    expect(snap.version).toBe(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- snapshot profile state after first event and then every 10 events
- add unit tests for snapshot logic
- document API and usage in English and Russian

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68994955d3e08322939ac7d7fa2b3d96